### PR TITLE
Add sprig functions to template.FuncMap

### DIFF
--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig"
 	"github.com/knq/snaker"
 	"github.com/knq/xo/models"
 )
 
 // NewTemplateFuncs returns a set of template funcs bound to the supplied args.
 func (a *ArgType) NewTemplateFuncs() template.FuncMap {
-	return template.FuncMap{
+	funcs := template.FuncMap{
 		"colcount":           a.colcount,
 		"colnames":           a.colnames,
 		"colnamesmulti":      a.colnamesmulti,
@@ -33,6 +34,12 @@ func (a *ArgType) NewTemplateFuncs() template.FuncMap {
 		"hasfield":           a.hasfield,
 		"getstartcount":      a.getstartcount,
 	}
+	for k, v := range sprig.FuncMap() {
+		if _, exists := funcs[k]; !exists {
+			funcs[k] = v
+		}
+	}
+	return funcs
 }
 
 // retype checks typ against known types, and prefixing


### PR DESCRIPTION
Add the template functions from the sprig library (https://github.com/Masterminds/sprig).
Relates to ticket #137 and pull request #148 .