### PR TITLE
Added UnfilteredFields property to have ignored fields accessible in templates

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -147,9 +147,10 @@ func (tl TypeLoader) ParseQuery(args *ArgType) error {
 
 	// create template for query type
 	typeTpl := &Type{
-		Name:    args.QueryType,
-		RelType: Table,
-		Fields:  []*Field{},
+		Name:             args.QueryType,
+		RelType:          Table,
+		Fields:           []*Field{},
+		UnfilteredFields: []*Field{}, // Maybe we should populate this in here also?
 		Table: &models.Table{
 			TableName: "[custom " + strings.ToLower(snaker.CamelToSnake(args.QueryType)) + "]",
 		},
@@ -471,11 +472,12 @@ func (tl TypeLoader) LoadRelkind(args *ArgType, relType RelType) (map[string]*Ty
 	for _, ti := range tableList {
 		// create template
 		typeTpl := &Type{
-			Name:    SingularizeIdentifier(ti.TableName),
-			Schema:  args.Schema,
-			RelType: relType,
-			Fields:  []*Field{},
-			Table:   ti,
+			Name:             SingularizeIdentifier(ti.TableName),
+			Schema:           args.Schema,
+			RelType:          relType,
+			Fields:           []*Field{},
+			UnfilteredFields: []*Field{},
+			Table:            ti,
 		}
 
 		// process columns
@@ -524,10 +526,6 @@ func (tl TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 			}
 		}
 
-		if ignore {
-			continue
-		}
-
 		// set col info
 		f := &Field{
 			Name: snaker.SnakeToCamelIdentifier(c.ColumnName),
@@ -542,6 +540,11 @@ func (tl TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 			typeTpl.PrimaryKey = f
 		}
 
+		// append col to template unfiltered fields
+		typeTpl.UnfilteredFields = append(typeTpl.UnfilteredFields, f)
+		if ignore {
+			continue
+		}
 		// append col to template fields
 		typeTpl.Fields = append(typeTpl.Fields, f)
 	}

--- a/internal/types.go
+++ b/internal/types.go
@@ -125,6 +125,7 @@ type Type struct {
 	PrimaryKey       *Field
 	PrimaryKeyFields []*Field
 	Fields           []*Field
+	UnfilteredFields []*Field
 	Table            *models.Table
 	Comment          string
 }


### PR DESCRIPTION
In order to have more flexibility in generation we need to have all the schema fields present in templates even if those are ignored when generation is invoked. In example if I have date/timestamp fields that are automatically handled by database just like in example I still want to have those accessible in the type and some select queries.

In this change I have added UnfilteredFields property to Type that contains all the fields possible.

As you can see from the comment under TypeLoader ParseQuery method that Fields property is used differently when query mode is enabled and I'm not sure what would be best way to handle UnfilteredFields in this scenario, just have same fields as Fields as ignoring is not handled in this case at all. One thing could be that the whole field logic would be changed that the Field itself contains info if its ignored or not but its a way more bc breaking change.