### PR TITLE
Log goimport errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -356,5 +356,10 @@ func writeTypes(args *internal.ArgType) error {
 	}
 
 	// process written files with goimports
-	return exec.Command("goimports", params...).Run()
+	output, err := exec.Command("goimports", params...).CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+
+	return nil
 }


### PR DESCRIPTION
Right now exec-ing goimports ignores any error output. This makes debugging really difficult when you have some generated template error that goimports doesn't like.

This PR dumps stderr/stdout of the goimports exec if goimports fails.