### PR TITLE
Better missing goimports error

### DIFF
--- a/main.go
+++ b/main.go
@@ -356,7 +356,12 @@ func writeTypes(args *internal.ArgType) error {
 	}
 
 	// process written files with goimports
-	output, err := exec.Command("goimports", params...).CombinedOutput()
+	_, err = exec.LookPath("goimports")
+	if err != nil {
+		return err
+	}
+
+	output, err := exec.Command("gorimports", params...).CombinedOutput()
 	if err != nil {
 		return errors.New(string(output))
 	}

--- a/main.go
+++ b/main.go
@@ -361,7 +361,7 @@ func writeTypes(args *internal.ArgType) error {
 		return err
 	}
 
-	output, err := exec.Command("gorimports", params...).CombinedOutput()
+	output, err := exec.Command("goimports", params...).CombinedOutput()
 	if err != nil {
 		return errors.New(string(output))
 	}


### PR DESCRIPTION
If `goimports` isn't available in a user's path, `xo` currently throws a very confusing blank error:

```
$ rm -rf /tmp/deleteme; mkdir /tmp/deleteme; go run main.go pgsql://localhost/postgres -o /tmp/deleteme
error:
exit status 1
```

When I was given this error, I had to go as far as cloning xo and running it in delve inside my container to figure out what was going on.

This PR makes it throw a nicer error if `goimports` isn't found on the user's `PATH`:

```
$ rm -rf /tmp/deleteme; mkdir /tmp/deleteme; go run main.go pgsql://localhost/postgres -o /tmp/deleteme
error: exec: "goimports": executable file not found in $PATH
exit status 1
```