### PR TITLE
distinct funcName and generate query code for combined indexes

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -703,10 +703,20 @@ func (tl TypeLoader) LoadTableIndexes(args *ArgType, typeTpl *Type, ixMap map[st
 			return err
 		}
 
-		// build func name
-		args.BuildIndexFuncName(ixTpl)
-
-		ixMap[typeTpl.Table.TableName+"_"+ix.IndexName] = ixTpl
+		l := len(ixTpl.Fields)
+		for i := 0; i < l; i++ {
+			// fake index according to Leftmost Prefixing for generating query func
+			ixTplNew := &Index{
+				Schema: args.Schema,
+				Type:   typeTpl,
+				Fields: ixTpl.Fields[:l-i],
+				Index:  ix,
+			}
+			// build func name
+			args.BuildIndexFuncName(ixTplNew)
+			// distinct func name
+			ixMap[ixTplNew.FuncName] = ixTplNew
+		}
 	}
 
 	// search for primary key if it was skipped being set in the type


### PR DESCRIPTION
There's a need to generate query codes for combined indexes according to Leftmost Prefixing. But I found it hard to implement the need using templates only. This means I need to generate several query functions from one combined index, so I also need to distinct function name generated. If the changing is also helpful to others, I hope it can be approved.