### PR TITLE
Add --disable-singularize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ options:
                          enable postgres oids
   --name-conflict-suffix NAME-CONFLICT-SUFFIX, -w NAME-CONFLICT-SUFFIX
                          suffix to append when a name conflicts with a Go variable [default: Val]
+  --disable-singularize
+                         singularization table name or not
   --template-path TEMPLATE-PATH
                          user supplied template path
   --help, -h             display this help and exit

--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -116,6 +116,9 @@ type ArgType struct {
 	// NameConflictSuffix is the suffix used when a name conflicts with a scoped Go variable.
 	NameConflictSuffix string `arg:"--name-conflict-suffix,-w,help:suffix to append when a name conflicts with a Go variable"`
 
+	// DisableSingularizeTableName toggles singularization table name when normalization it
+	DisableSingularizeTableName bool `arg:"--disable-singularize,help:singularization table name or not"`
+
 	// TemplatePath is the path to use the user supplied templates instead of
 	// the built in versions.
 	TemplatePath string `arg:"--template-path,help:user supplied template path"`

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -471,7 +471,7 @@ func (tl TypeLoader) LoadRelkind(args *ArgType, relType RelType) (map[string]*Ty
 	for _, ti := range tableList {
 		// create template
 		typeTpl := &Type{
-			Name:    SingularizeIdentifier(ti.TableName),
+			Name:    NormalizeIdentifier(ti.TableName, args.DisableSingularizeTableName),
 			Schema:  args.Schema,
 			RelType: relType,
 			Fields:  []*Field{},

--- a/internal/util.go
+++ b/internal/util.go
@@ -222,6 +222,15 @@ func SingularizeIdentifier(s string) string {
 	return snaker.SnakeToCamelIdentifier(s)
 }
 
+// NormalizeIdentifier normalizes the given string, returning it in
+// CamelCase.
+func NormalizeIdentifier(s string, noSingularize bool) string {
+	if noSingularize {
+		return snaker.SnakeToCamelIdentifier(s)
+	}
+	return SingularizeIdentifier(s)
+}
+
 // TBuf is to hold the executed templates.
 type TBuf struct {
 	TemplateType TemplateType


### PR DESCRIPTION
https://github.com/xo/xo/issues/203

In addition, if two tables have similar names, `user_type` and `user_types` for example, two structs with the same name will be generated with different fields. So sad!

This PR will fix this.