### PR TITLE
Add IsForeignKey to Column struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ashneverdawn/xo
+module github.com/xo/xo
 
 require (
 	cloud.google.com/go v0.34.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xo/xo
+module github.com/ashneverdawn/xo
 
 require (
 	cloud.google.com/go v0.34.0 // indirect

--- a/models/column.xo.go
+++ b/models/column.xo.go
@@ -29,7 +29,7 @@ func PgTableColumns(db XODB, schema string, table string, sys bool) ([]*Column, 
 		`format_type(a.atttypid, a.atttypmod), ` + // ::varchar AS data_type
 		`a.attnotnull, ` + // ::boolean AS not_null
 		`COALESCE(pg_get_expr(ad.adbin, ad.adrelid), ''), ` + // ::varchar AS default_value
-		`COALESCE(ct.contype = 'p', false) ` + // ::boolean AS is_primary_key
+		`COALESCE(ct.contype = 'p', false), ` + // ::boolean AS is_primary_key
 		`COALESCE(ct.contype = 'f', false) ` + // ::boolean AS is_primary_key
 		`FROM pg_attribute a ` +
 		`JOIN ONLY pg_class c ON c.oid = a.attrelid ` +


### PR DESCRIPTION
This small and simple change allows access to know if a field is a foreign key or not in a custom template.

For example:
`
{{range .Fields}} 
{{if .Col.IsForeignKey}} {{ .Name}} {{end}}
{{end}}
`