### PR TITLE
Added support for MSSql Nullable Datetime

### DIFF
--- a/loaders/mssql.go
+++ b/loaders/mssql.go
@@ -155,7 +155,10 @@ func MsParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 	case "datetime", "datetime2", "timestamp":
 		nilVal = "time.Time{}"
 		typ = "time.Time"
-
+		if nullable {
+			nilVal = "sql.NullTime{}"
+			typ = "sql.NullTime"
+		}
 	case "time with time zone", "time without time zone", "timestamp without time zone":
 		nilVal = "0"
 		typ = "int64"


### PR DESCRIPTION
A small change in `MsParseType` function to support Nullable Datetime types.
I have no idea if there was a reason to not include it since the beginning.