### PR TITLE
Fix Insert issue for default postgres type template Insert operation

### DIFF
--- a/templates/postgres.type.go.tpl
+++ b/templates/postgres.type.go.tpl
@@ -46,7 +46,7 @@ func ({{ $short }} *{{ .Name }}) Insert(db XODB) error {
 
 	// run query
 	XOLog(sqlstr, {{ fieldnames .Fields $short }})
-	err = db.QueryRow(sqlstr, {{ fieldnames .Fields $short }}).Scan(&{{ $short }}.{{ .PrimaryKey.Name }})
+	_, err = db.Exec(sqlstr, {{ fieldnames .Fields $short }})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As far as I can tell, the `.Scan` here will always fail without the `RETURNING` clause in the SQL (tried with a couple different drivers, `lib/pq` and `pgx`. Rather than add `RETURNING` when the primary key is set manually, I opted to just use `Exec` rather than `QueryRow`.