### PR TITLE
Failed to generate model files if has a `id` or `ids` table at databases

### DIFF
--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -108,13 +108,18 @@ func (a *ArgType) shortname(typ string, scopeConflicts ...interface{}) string {
 	if v, ok = a.ShortNameTypeMap[typ]; !ok {
 		// calc the short name
 		u := []string{}
-		for _, s := range strings.Split(strings.ToLower(snaker.CamelToSnake(typ)), "_") {
-			if len(s) > 0 && s != "id" {
-				u = append(u, s[:1])
-			} else if s == "id" {
-				u = append(u, "i")
+
+		receiverElements := strings.Split(strings.ToLower(snaker.CamelToSnake(typ)), "_")
+		if len(receiverElements) == 1 && receiverElements[0] == "id" {
+			u = append(u, "i")
+		} else {
+			for _, s := range receiverElements {
+				if len(s) > 0 && s != "id" {
+					u = append(u, s[:1])
+				}
 			}
 		}
+
 		v = strings.Join(u, "")
 
 		// check go reserved names

--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -111,6 +111,8 @@ func (a *ArgType) shortname(typ string, scopeConflicts ...interface{}) string {
 		for _, s := range strings.Split(strings.ToLower(snaker.CamelToSnake(typ)), "_") {
 			if len(s) > 0 && s != "id" {
 				u = append(u, s[:1])
+			} else if s == "id" {
+				u = append(u, "i")
 			}
 		}
 		v = strings.Join(u, "")


### PR DESCRIPTION
This occurs to function `shortname(typ string..)` in `internal/funcs.go`.

This function to generates the struct reciever name using to generate model files from typ variable.

The variable name of the camel case is changed to a snake case, split with an underscore to convert it to an array, and the combined initials of each are used to resolve the receiver name.

Here, if an element of the array has an `id` when generating the receiver name, it is ignored as follows.

https://github.com/xo/xo/blob/7818603ff52bc0b96122715f9c7df7559aeef82d/internal/funcs.go#L108-L125

This means that if the entered table name is `id`, an null character is used instead of a proper receiver name, and this causes an error in the generated file.

This `typ` variable set by `internal/loader.go:L474`. Plural table names are converted and saved to singular.
So, if the table name is `ids`. It  is vconverted to `id` 

Eventually this table name will be used by the function `shortname` and an error will occur.

In this pull request, if the table name is `id` or `ids`, the name of the receiver is set to `i`, which solves this problem.

I would also like to ask about this process, why is `id` ignored here?