### PR TITLE
Fixing a minor issue with the Go typedef template

### DIFF
--- a/templates/gotpl/schema/typedef.xo.go.tpl
+++ b/templates/gotpl/schema/typedef.xo.go.tpl
@@ -44,7 +44,7 @@ func ({{ $short }} *{{ $type.Name }}) Insert{{ if context_both }}Context{{ end }
 		`)`
 	// run
 	logf(sqlstr, {{ fieldnames $type.Fields $short }})
-	if err := db.QueryRow{{ if context }}Context{{ end }}({{ if context }}ctx, {{ end }}sqlstr, {{ fieldnames $type.Fields $short }}).Scan(&{{ $short }}.{{ $type.PrimaryKey.Name }}); err != nil {
+	if _, err := db.Exec{{ if context }}Context{{ end }}({{ if context }}ctx, {{ end }}sqlstr, {{ fieldnames $type.Fields $short }}); err != nil {
 		return logerror(err)
 	}
 {{- else -}}


### PR DESCRIPTION
This changes the generated code for the Insert function, when the
primary key is manually handled. This code would always fail as no row
is returned in an insert with a manual primary key. This change instead
uses Exec, and does not scan anything back.