### PR TITLE
readme: update note about templ languages created by xo dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ $ go generate
 $ git add templates gen.go && git commit -m 'Adding custom xo templates for models'
 ```
 
-> **Note**: using `xo dump` will create templates for all languages. You can
-safely delete templates used for code generation for the other languages.
+> **Note**: via the `--template` parameter of `xo dump` you can create
+templates for other languages. The default is `go`.
 
 ### Template Language/Syntax
 


### PR DESCRIPTION
The note was outdated.
"xo dump" is by default only creating templates for the Go language
instead of for all languages.
Therefore there are by default also no templates for other languages
that can be deleted.