### PR TITLE
go template: use switch-var that is less likely to name collide

### DIFF
--- a/templates/gotpl/schema/enum.xo.go.tpl
+++ b/templates/gotpl/schema/enum.xo.go.tpl
@@ -28,13 +28,13 @@ func ({{ short $e.GoName }} {{ $e.GoName }}) MarshalText() ([]byte, error) {
 
 // UnmarshalText unmarshals {{ $e.GoName }} from text.
 func ({{ short $e.GoName }} *{{ $e.GoName }}) UnmarshalText(buf []byte) error {
-	switch svar := string(buf); svar {
+	switch str := string(buf); str {
 {{ range $e.Values -}}
 	case "{{ .SQLName }}":
 		*{{ short $e.GoName }} = {{ $e.GoName }}{{ .GoName }}
 {{ end -}}
 	default:
-		return ErrInvalid{{ $e.GoName }}(svar)
+		return ErrInvalid{{ $e.GoName }}(str)
 	}
 	return nil
 }

--- a/templates/gotpl/schema/enum.xo.go.tpl
+++ b/templates/gotpl/schema/enum.xo.go.tpl
@@ -28,13 +28,13 @@ func ({{ short $e.GoName }} {{ $e.GoName }}) MarshalText() ([]byte, error) {
 
 // UnmarshalText unmarshals {{ $e.GoName }} from text.
 func ({{ short $e.GoName }} *{{ $e.GoName }}) UnmarshalText(buf []byte) error {
-	switch s := string(buf); s {
+	switch svar := string(buf); svar {
 {{ range $e.Values -}}
 	case "{{ .SQLName }}":
 		*{{ short $e.GoName }} = {{ $e.GoName }}{{ .GoName }}
 {{ end -}}
 	default:
-		return ErrInvalid{{ $e.GoName }}(s)
+		return ErrInvalid{{ $e.GoName }}(svar)
 	}
 	return nil
 }


### PR DESCRIPTION
The UnmarshalText() method of a Go-Enum generated code used for a
variable switch-statement the name "s".
If the type name started with s like "Salutation", the generated method
receiver name used the same name, also s.

This caused the switch-statement code to break. Both variables that are
accessed in it were called "s", the assignment were done to the
switch-variable instead of to the method receiver var.

Rename the switch var to be called "svar", this should make naming
collisions much more unlikely.

This fixes https://github.com/xo/xo/issues/310.
If you know a better way to fix it, feel free to close my PR. :-)