### PR TITLE
go template: fix: update statement for composite primary keys is broken

### DIFF
--- a/templates/gotpl/funcs.go.tpl
+++ b/templates/gotpl/funcs.go.tpl
@@ -779,7 +779,7 @@ func (f *Funcs) sqlstr_update(v interface{}) []string {
 		for i, z := range x.PrimaryKeys {
 			list = append(list, fmt.Sprintf("%s = %s", f.colname(z), f.nth(n+i)))
 		}
-		return append(lines, "WHERE "+strings.Join(list, ", "))
+		return append(lines, "WHERE "+strings.Join(list, " AND "))
 	}
 	return []string{fmt.Sprintf("[[ UNSUPPORTED TYPE 20: %T ]]", v)}
 }


### PR DESCRIPTION
The generated Update SQL statement for tables that had composite primary
keys were invalid.
The columns in the WHERE clause where concatenated with an ", " instead
of " AND ".

In the generated where clause the primary keys are concatenated with an , instead of AND.

This fixes https://github.com/xo/xo/issues/325