### PR TITLE
templates/gotpl: fix typo on documentations

### DIFF
--- a/templates/gotpl/funcs.go.tpl
+++ b/templates/gotpl/funcs.go.tpl
@@ -922,7 +922,7 @@ func (f *Funcs) sqlstr_delete(v interface{}) []string {
 	return []string{fmt.Sprintf("[[ UNSUPPORTED TYPE 25: %T ]]", v)}
 }
 
-// sqlstr_index builds a
+// sqlstr_index builds a index fields.
 func (f *Funcs) sqlstr_index(v interface{}) []string {
 	switch x := v.(type) {
 	case gotpl.Index:

--- a/templates/gotpl/funcs.go.tpl
+++ b/templates/gotpl/funcs.go.tpl
@@ -591,7 +591,7 @@ func (f *Funcs) names_all(prefix string, z ...interface{}) string {
 	return f.namesfn(true, prefix, z...)
 }
 
-// names_all generates a list of all names, ignoring fields that match the value in ignore.
+// names_ignore generates a list of all names, ignoring fields that match the value in ignore.
 func (f *Funcs) names_ignore(prefix string, v interface{}, ignore ...string) string {
 	m := map[string]bool{}
 	for _, n := range ignore {
@@ -674,7 +674,7 @@ func (f *Funcs) sqlstr(typ string, v interface{}) string {
 	return fmt.Sprintf("const sqlstr = `%s`", strings.Join(lines, "` +\n\t`"))
 }
 
-// sqlstr_insert_manual builds an INSERT query
+// sqlstr_insert_base builds an INSERT query
 // If not all, sequence columns are skipped.
 func (f *Funcs) sqlstr_insert_base(all bool, v interface{}) []string {
 	switch x := v.(type) {

--- a/templates/gotpl/gotpl.go
+++ b/templates/gotpl/gotpl.go
@@ -687,7 +687,7 @@ func First(ctx context.Context) *bool {
 	return b
 }
 
-// KnownTYpes returns known-types from the context.
+// KnownTypes returns known-types from the context.
 func KnownTypes(ctx context.Context) map[string]bool {
 	m, _ := ctx.Value(KnownTypesKey).(map[string]bool)
 	return m
@@ -825,7 +825,7 @@ func contains(v []string, s string) bool {
 	return false
 }
 
-// singuralize singularizes s.
+// singularize singularizes s.
 func singularize(s string) string {
 	if i := strings.LastIndex(s, "_"); i != -1 {
 		return s[:i+1] + inflector.Singularize(s[i+1:])


### PR DESCRIPTION
Fix typo on documentations and complete `sqlstr_index` documentations in `templates/gotpl` package.