### PR TITLE
fix: Add correct join clause for postgres enum queries

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -61,8 +61,10 @@ ENDSQL
 COMMENT='{{ . }} is a enum.'
 $XOBIN query $PGDB -M -B -2 -T Enum -F PostgresEnums --type-comment "$COMMENT" -o $DEST $@ << ENDSQL
 SELECT
-  c.relname AS table_name, t.typname::varchar AS enum_name
-FROM pg_class c, pg_type t
+  DISTINCT c.relname AS table_name, t.typname::varchar AS enum_name
+FROM pg_class c
+  JOIN pg_attribute a ON c.oid = a.attrelid
+  JOIN pg_type t on a.atttypid = t.oid
   JOIN ONLY pg_namespace n ON n.oid = t.typnamespace
   JOIN ONLY pg_enum e ON t.oid = e.enumtypid
 WHERE n.nspname = %%schema string%%
@@ -74,7 +76,9 @@ $XOBIN query $PGDB -M -B -2 -T EnumValue -F PostgresEnumValues --type-comment "$
 SELECT
   e.enumlabel::varchar AS enum_value,
   e.enumsortorder::integer AS const_value
-FROM pg_class c, pg_type t
+FROM pg_class c
+  JOIN pg_attribute a ON c.oid = a.attrelid
+  JOIN pg_type t on a.atttypid = t.oid
   JOIN ONLY pg_namespace n ON n.oid = t.typnamespace
   LEFT JOIN pg_enum e ON t.oid = e.enumtypid
 WHERE n.nspname = %%schema string%%

--- a/models/enum.xo.go
+++ b/models/enum.xo.go
@@ -15,9 +15,11 @@ type Enum struct {
 // PostgresEnums runs a custom query, returning results as Enum.
 func PostgresEnums(ctx context.Context, db DB, schema string) ([]*Enum, error) {
 	// query
-	const sqlstr = `SELECT ` +
+	const sqlstr = `SELECT DISTINCT ` +
 		`c.relname AS table_name, t.typname ` + // ::varchar AS enum_name
-		`FROM pg_class c, pg_type t ` +
+		`FROM pg_class c ` +
+		`JOIN pg_attribute a ON c.oid = a.attrelid ` +
+		`JOIN pg_type t on a.atttypid = t.oid ` +
 		`JOIN ONLY pg_namespace n ON n.oid = t.typnamespace ` +
 		`JOIN ONLY pg_enum e ON t.oid = e.enumtypid ` +
 		`WHERE n.nspname = $1`

--- a/models/enumvalue.xo.go
+++ b/models/enumvalue.xo.go
@@ -18,7 +18,9 @@ func PostgresEnumValues(ctx context.Context, db DB, schema, table, enum string) 
 	const sqlstr = `SELECT ` +
 		`e.enumlabel, ` + // ::varchar AS enum_value
 		`e.enumsortorder ` + // ::integer AS const_value
-		`FROM pg_class c, pg_type t ` +
+		`FROM pg_class c ` +
+		`JOIN pg_attribute a ON c.oid = a.attrelid ` +
+		`JOIN pg_type t on a.atttypid = t.oid ` +
 		`JOIN ONLY pg_namespace n ON n.oid = t.typnamespace ` +
 		`LEFT JOIN pg_enum e ON t.oid = e.enumtypid ` +
 		`WHERE n.nspname = $1 ` +


### PR DESCRIPTION
Currently, the query is generating tons of irrelevant results since missing the join criteria for `pg_class` table, thus introducing the issue #339.
 
This commit adds the correct join criteria between the `pg_class` table and `pg_type` table to fix it.