### PR TITLE
readme: update mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ Additionally, when working with date/time column types in MySQL, one should
 pass the `parseTime=true` option to the MySQL driver:
 
 ```sh
-$ xo 'mysql://user:pass@host/dbname?parseTime=true' -o models
+$ xo schema 'mysql://user:pass@host/dbname?parseTime=true' -o models
 ```
 
 And when opening a database connection:


### PR DESCRIPTION
The readme was outdated.
There was no schema description and the xo command was failing.
Fixed to add schema and run correctly