### PR TITLE
Add generated xo.XO to the context

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -46,12 +46,13 @@ func Run(ctx context.Context, name, version string) error {
 			f = BuildQuery
 		}
 		// build
-		x := new(xo.XO)
-		if err := f(ctx, args, x); err != nil {
+		v := new(xo.XO)
+		if err := f(ctx, args, v); err != nil {
 			return err
 		}
+		ctx = context.WithValue(ctx, templates.XOKey, v)
 		// process
-		if err := templates.Process(ctx, args.OutParams.Append, args.OutParams.Single, x); err != nil {
+		if err := templates.Process(ctx, args.OutParams.Append, args.OutParams.Single, v); err != nil {
 			return err
 		}
 	}

--- a/internal/github_com-goccy-go-yaml.go
+++ b/internal/github_com-goccy-go-yaml.go
@@ -154,9 +154,7 @@ type _github_com_goccy_go_yaml_FieldError struct {
 	WStructField func() string
 }
 
-func (W _github_com_goccy_go_yaml_FieldError) StructField() string {
-	return W.WStructField()
-}
+func (W _github_com_goccy_go_yaml_FieldError) StructField() string { return W.WStructField() }
 
 // _github_com_goccy_go_yaml_InterfaceMarshaler is an interface wrapper for InterfaceMarshaler type
 type _github_com_goccy_go_yaml_InterfaceMarshaler struct {
@@ -204,9 +202,7 @@ type _github_com_goccy_go_yaml_IsZeroer struct {
 	WIsZero func() bool
 }
 
-func (W _github_com_goccy_go_yaml_IsZeroer) IsZero() bool {
-	return W.WIsZero()
-}
+func (W _github_com_goccy_go_yaml_IsZeroer) IsZero() bool { return W.WIsZero() }
 
 // _github_com_goccy_go_yaml_StructValidator is an interface wrapper for StructValidator type
 type _github_com_goccy_go_yaml_StructValidator struct {
@@ -214,6 +210,4 @@ type _github_com_goccy_go_yaml_StructValidator struct {
 	WStruct func(a0 interface{}) error
 }
 
-func (W _github_com_goccy_go_yaml_StructValidator) Struct(a0 interface{}) error {
-	return W.WStruct(a0)
-}
+func (W _github_com_goccy_go_yaml_StructValidator) Struct(a0 interface{}) error { return W.WStruct(a0) }

--- a/internal/github_com-xo-xo-templates.go
+++ b/internal/github_com-xo-xo-templates.go
@@ -32,6 +32,8 @@ func init() {
 		"Write":           reflect.ValueOf(templates.Write),
 		"WriteFiles":      reflect.ValueOf(templates.WriteFiles),
 		"WriteRaw":        reflect.ValueOf(templates.WriteRaw),
+		"XO":              reflect.ValueOf(templates.XO),
+		"XOKey":           reflect.ValueOf(templates.XOKey),
 
 		// type definitions
 		"EmittedTemplate": reflect.ValueOf((*templates.EmittedTemplate)(nil)),

--- a/templates/gotpl/gotpl.go
+++ b/templates/gotpl/gotpl.go
@@ -402,6 +402,23 @@ func emitSchema(ctx context.Context, set *templates.TemplateSet, s xo.Schema) er
 		if err != nil {
 			return err
 		}
+		// emit indexes
+		for _, i := range t.Indexes {
+			index, err := convertIndex(ctx, table, i)
+			if err != nil {
+				return err
+			}
+			table.Indexes = append(table.Indexes, index)
+		}
+
+		// emit fkeys
+		for _, fk := range t.ForeignKeys {
+			fkey, err := convertFKey(ctx, table, fk)
+			if err != nil {
+				return err
+			}
+			table.ForeignKeys = append(table.ForeignKeys, fkey)
+		}
 		if err := set.Emit(ctx, &templates.Template{
 			Set:      "schema",
 			Template: "typedef",
@@ -410,12 +427,7 @@ func emitSchema(ctx context.Context, set *templates.TemplateSet, s xo.Schema) er
 		}); err != nil {
 			return err
 		}
-		// emit indexes
-		for _, i := range t.Indexes {
-			index, err := convertIndex(ctx, table, i)
-			if err != nil {
-				return err
-			}
+		for _, index := range table.Indexes {
 			if err := set.Emit(ctx, &templates.Template{
 				Set:      "schema",
 				Template: "index",
@@ -426,12 +438,7 @@ func emitSchema(ctx context.Context, set *templates.TemplateSet, s xo.Schema) er
 				return err
 			}
 		}
-		// emit fkeys
-		for _, fk := range t.ForeignKeys {
-			fkey, err := convertFKey(ctx, table, fk)
-			if err != nil {
-				return err
-			}
+		for _, fkey := range table.ForeignKeys {
 			if err := set.Emit(ctx, &templates.Template{
 				Set:      "schema",
 				Template: "foreignkey",

--- a/templates/gotpl/types.go
+++ b/templates/gotpl/types.go
@@ -42,6 +42,9 @@ type Table struct {
 	Fields      []Field
 	Manual      bool
 	Comment     string
+
+	Indexes     []Index
+	ForeignKeys []ForeignKey
 }
 
 // ForeignKey is a foreign key template.

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -460,6 +460,7 @@ func (err *ErrPostFailed) Unwrap() error {
 
 // Context keys.
 const (
+	XOKey           xo.ContextKey = "xo"
 	SymbolsKey      xo.ContextKey = "symbols"
 	GenTypeKey      xo.ContextKey = "gen-type"
 	TemplateTypeKey xo.ContextKey = "template-type"
@@ -467,6 +468,11 @@ const (
 	SrcKey          xo.ContextKey = "src"
 	OutKey          xo.ContextKey = "out"
 )
+
+func XO(ctx context.Context) *xo.XO {
+	v, _ := ctx.Value(XOKey).(*xo.XO)
+	return v
+}
 
 // Symbols returns the symbols option from the context.
 func Symbols(ctx context.Context) map[string]map[string]reflect.Value {


### PR DESCRIPTION
This change makes the generated `xo.XO` accessible from templates.

This is needed because in some situations, (such as from the typedef template), access to the entire list of foreign keys or indices is required. 