### PR TITLE
Adding string check to custom enums for Scan interface

### DIFF
--- a/templates/go/schema.xo.go.tpl
+++ b/templates/go/schema.xo.go.tpl
@@ -50,6 +50,9 @@ func ({{ short $e.GoName }} *{{ $e.GoName }}) Scan(v interface{}) error {
 	if buf, ok := v.([]byte); ok {
 		return {{ short $e.GoName }}.UnmarshalText(buf)
 	}
+	if buf, ok := v.(string); ok {
+		return {{ short $e.GoName }}.UnmarshalText([]byte(buf))
+	}
 	return ErrInvalid{{ $e.GoName }}(fmt.Sprintf("%T", v))
 }
 


### PR DESCRIPTION
Database : Postgres

Using custom enums of the string variety causes a Scan error as it is only looking for the type `[]byte` 

Here is an example of a custom type using strings:
```sql
CREATE TYPE address_kind AS ENUM ('billing', 'shipping', 'mailing');
```

An example of using the custom `address_kind` in a table:

```sql
CREATE TABLE customer_address (
    id bigserial PRIMARY KEY,
    store_id bigint NOT NULL,
    customer_id bigint NOT NULL,
    kind address_kind NOT NULL,
    is_default boolean DEFAULT FALSE NOT NULL,
    street character varying NOT NULL,
    apt_suite character varying NULL,
    city character varying NOT NULL,
    state_province character varying NOT NULL,
    country character varying NOT NULL,
    postal_code character varying NOT NULL,
    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NULL,
    deleted_at timestamp without time zone
);
CREATE INDEX IF NOT EXISTS idx_customer_address_store_id ON customer_address USING btree (store_id);
CREATE INDEX IF NOT EXISTS idx_customer_address_customer_id_kind ON customer_address USING btree (customer_id, kind);
```

Adding a string check after the byte check makes the Scan work correctly. 

```go
// Scan satisfies the sql.Scanner interface.
func ({{ short $e.GoName }} *{{ $e.GoName }}) Scan(v interface{}) error {
	if buf, ok := v.([]byte); ok {
		return {{ short $e.GoName }}.UnmarshalText(buf)
	}
	if buf, ok := v.(string); ok {
		return {{ short $e.GoName }}.UnmarshalText([]byte(buf))
	}
	return ErrInvalid{{ $e.GoName }}(fmt.Sprintf("%T", v))
}
```

If I am doing this wrong please correct me 👍 