### PR TITLE
add fieldalignment to SchemaParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Commands:
         --json-indent="  "         indent spacing
         --json-ugly                disable indentation
         --postgres-oids            enable postgres OIDs
+    -3  --fieldalign               enable fieldalignment
 
   dump [<flags>] <out>
     Dump internal templates to path.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -133,6 +133,10 @@ type SchemaParams struct {
 	// to indexes (for example, 'authors__b124214__u_idx' instead of the more
 	// descriptive 'authors_title_idx').
 	UseIndexNames bool
+	// Fieldalign toggles using fieldalignment.
+	//
+	// This not enabled by default, because the user may not want fieldalignment.
+	Fieldalign bool
 }
 
 // OutParams are out parameters.
@@ -266,6 +270,7 @@ func SchemaCommand(ctx context.Context, ts *templates.Set, args *Args) (*cobra.C
 	flags.VarP(args.SchemaParams.Include, "include", "i", args.SchemaParams.Include.Desc())
 	flags.VarP(args.SchemaParams.Exclude, "exclude", "e", args.SchemaParams.Exclude.Desc())
 	flags.BoolVarP(&args.SchemaParams.UseIndexNames, "use-index-names", "j", false, "use index names as defined in schema for generated code")
+	flags.BoolVarP(&args.SchemaParams.Fieldalign, "fieldalign", "3", false, "Fieldalign schema structs to save memory.")
 	if err := templateFlags(cmd, ts, true, args); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# What is fieldalignment?

**Struct padding** aligns fields of a structs to addresses in memory. This is done to improve performance and prevent numerous issues on a system's architecture (32-bit, 64-bit). For a simple explanation, view [Golang Struct Size and Memory optimization (visual example)](https://medium.com/techverito/golang-struct-size-and-memory-optimisation-b46b124f008d
). In Go, fieldalignment can be checked and fixed using the [fieldalignment tool](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/fieldalignment) which is installed using `go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest`. Misaligned fields add more memory-usage to a program, which can effect performance in a numerous amount of ways. **This proposal aims to save memory by adding fieldalignment to xo.**

### Read More
Fieldalignment in Practice: https://itnext.io/structure-size-optimization-in-golang-alignment-padding-more-effective-memory-layout-linters-fffdcba27c61
Memory Layouts: https://go101.org/article/memory-layout.html

## fieldalignment in xo

The following code block contains output from `fieldalignment -fix` on xo structs.
```go
xo.xo.go:13:14: struct with 16 pointer bytes could be 8
xo.xo.go:12:18: struct with 16 pointer bytes could be 8
xo.xo.go:12:14: struct with 16 pointer bytes could be 8
xo.xo.go:13:19: struct with 64 pointer bytes could be 48
xo.xo.go:13:21: struct with 40 pointer bytes could be 24
xo.xo.go:12:12: struct with 40 pointer bytes could be 24
xo.xo.go:13:12: struct with 72 pointer bytes could be 64
xo.xo.go:12:16: struct with 24 pointer bytes could be 8
xo.xo.go:13:14: struct with 56 pointer bytes could be 24
xo.xo.go:12:11: struct with 24 pointer bytes could be 8
xo.xo.go:13:14: struct with 64 pointer bytes could be 24
xo.xo.go:12:18: struct with 40 pointer bytes could be 24
xo.xo.go:13:11: struct with 48 pointer bytes could be 40
xo.xo.go:8:20: struct with 136 pointer bytes could be 104
```

240 bytes. 14 misaligned models. 17.1 bytes saved per model. You don't use these models in every request. So for each model used in 1 MILLION requests, _that's..._

**17.1 MB saved per misaligned model**. Along with better Garbage Collection performance due to a lower amount of peaks.

Along with better [Garbage Collection](https://agrim123.github.io/posts/go-garbage-collector.html) performance due to a lower amount of peaks.

## Steps

- [x] Add fieldalignment option.
- [ ] Add code to field align the written file. 
- [x] Add documentation on how to enable field alignment
- [ ] and install it using `go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest` if necessary.