### PR TITLE
readme: update installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following is a matrix of the feature support for each database:
 Install `xo` in the usual Go way:
 
 ```sh
-$ go get -u github.com/xo/xo
+$ go install github.com/xo/xo@latest
 ```
 
 > **Note:** Go 1.16+ is needed for building `xo` from source.


### PR DESCRIPTION
Since Go 1.16, which is also the documented min. version, the
recommended way to build and install applications is "go install"[^1].

Update the readme accordingly.

[^1]: https://go.dev/doc/go1.16#go-command