### PR TITLE
Make comments an empty slice when strip is not enabled

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -109,7 +109,7 @@ func ParseQuery(ctx context.Context, sqlstr, delimiter string, interpolate, trim
 		}
 	}
 	// build comments
-	var comments []string
+	comments := make([]string, len(query))
 	if strip {
 		// strip view
 		if query, inspect, comments, err = loader.ViewStrip(ctx, query, inspect); err != nil {


### PR DESCRIPTION
This makes xo not panic when `-B` is not provided.