### PR TITLE
#367 updated required Go version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install `xo` in the usual Go way:
 $ go install github.com/xo/xo@latest
 ```
 
-> **Note:** Go 1.16+ is needed for building `xo` from source.
+> **Note:** Go 1.19+ is needed for building `xo` from source.
 
 ## Quickstart
 


### PR DESCRIPTION
According to investigations in the issue [367](https://github.com/xo/xo/issues/367), xo/xo requires 1.19+ go version.
