### PR TITLE
fix: Fix typo in Go template

### DIFF
--- a/templates/go/go.go
+++ b/templates/go/go.go
@@ -2692,7 +2692,7 @@ func addLegacyFuncs(ctx context.Context, funcs template.FuncMap) {
 		}
 		return expr
 	}
-	// getstartcount returns a starting count for numbering columsn in queries
+	// getstartcount returns a starting count for numbering columns in queries
 	funcs["getstartcount"] = func(fields []*Field, pkFields []*Field) int {
 		return len(fields) - len(pkFields)
 	}


### PR DESCRIPTION
SSIA

I tried to run `xo dump` and customized the template. And then found a misspelling.

```
$ go install github.com/xo/xo@latest
$ go install github.com/client9/misspell/cmd/misspell@latest
$ xo dump -t go .
$ misspell .
go.go:2695:57: "columsn" is a misspelling of "columns"
```
