### PR TITLE
#374 provide a comment of the column into structure used in Templates

### DIFF
--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -263,6 +263,7 @@ func LoadColumns(ctx context.Context, args *Args, table *xo.Table) error {
 			Default:    defaultValue,
 			IsPrimary:  c.IsPrimaryKey,
 			IsSequence: sqMap[c.ColumnName],
+			Comment:    c.Comment.String,
 		}
 		table.Columns = append(table.Columns, col)
 		if col.IsPrimary {

--- a/gen.sh
+++ b/gen.sh
@@ -172,7 +172,7 @@ WHERE n.nspname = %%schema string%%
 ENDSQL
 
 # postgres table column list query
-FIELDS='FieldOrdinal int,ColumnName string,DataType string,NotNull bool,DefaultValue sql.NullString,IsPrimaryKey bool'
+FIELDS='FieldOrdinal int,ColumnName string,DataType string,NotNull bool,DefaultValue sql.NullString,IsPrimaryKey bool,Comment sql.NullString'
 COMMENT='{{ . }} is a column.'
 $XOBIN query $PGDB -M -B -2 -T Column -F PostgresTableColumns -Z "$FIELDS" --type-comment "$COMMENT" -o $DEST $@ << ENDSQL
 SELECT
@@ -181,7 +181,8 @@ SELECT
   format_type(a.atttypid, a.atttypmod)::varchar AS data_type,
   a.attnotnull::boolean AS not_null,
   COALESCE(pg_get_expr(ad.adbin, ad.adrelid), '')::varchar AS default_value,
-  COALESCE(ct.contype = 'p', false)::boolean AS is_primary_key
+  COALESCE(ct.contype = 'p', false)::boolean AS is_primary_key,
+  d.description::varchar as comment
 FROM pg_attribute a
   JOIN ONLY pg_class c ON c.oid = a.attrelid
   JOIN ONLY pg_namespace n ON n.oid = c.relnamespace
@@ -190,6 +191,8 @@ FROM pg_attribute a
     AND ct.contype = 'p'
   LEFT JOIN pg_attrdef ad ON ad.adrelid = c.oid
     AND ad.adnum = a.attnum
+  LEFT JOIN pg_description d on d.objoid = c.oid
+		AND d.objsubid = a.attnum
 WHERE a.attisdropped = false
   AND n.nspname = %%schema string%%
   AND c.relname = %%table string%%
@@ -403,7 +406,8 @@ SELECT
   IF(data_type = 'enum', column_name, column_type) AS data_type,
   IF(is_nullable = 'YES', false, true) AS not_null,
   column_default AS default_value,
-  IF(column_key = 'PRI', true, false) AS is_primary_key
+  IF(column_key = 'PRI', true, false) AS is_primary_key,
+  column_comment AS comment
 FROM information_schema.columns
 WHERE table_schema = %%schema string%%
   AND table_name = %%table string%%

--- a/templates/go/go.go
+++ b/templates/go/go.go
@@ -746,6 +746,7 @@ func convertField(ctx context.Context, tf transformFunc, f xo.Field) (Field, err
 		Zero:       zero,
 		IsPrimary:  f.IsPrimary,
 		IsSequence: f.IsSequence,
+		Comment:    f.Comment,
 	}, nil
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -136,6 +136,7 @@ type Field struct {
 	ConstValue  *int   `json:"const_value,omitempty"`
 	Interpolate bool   `json:"interpolate,omitempty"`
 	Join        bool   `json:"join,omitempty"`
+	Comment     string `json:"comment,omitempty"`
 }
 
 // Type holds information for a database type.
@@ -154,11 +155,11 @@ type Type struct {
 //
 // Expected formats:
 //
-//	type
-//	type(precision)
-//	type(precision, scale)
-//  type(precision, scale) unsigned
-//	timestamp(n) with [local] time zone (oracle only)
+//		type
+//		type(precision)
+//		type(precision, scale)
+//	 type(precision, scale) unsigned
+//		timestamp(n) with [local] time zone (oracle only)
 //
 // The returned type is stripped of precision and scale.
 func ParseType(typ, driver string) (Type, error) {


### PR DESCRIPTION
Hello, here's my attempt to implement the issue described there:
https://github.com/xo/xo/issues/374

I've made changes only for PostgreSQL and MySQL

Short list of the changes:

1. gen.sh - enrich SQL query to get table's column's comment from pg_description table
2. types/types.go - added Comment field to the Field struct
3. cmd/schema.go - passed new value from query result to xo.Field
4. models/column.xo.go - generated stuff
5. templates/go/go.go - changes in the standard templates