### PR TITLE
Fix Issue #387 - Run xo fails on Windows OS

### DIFF
--- a/templates/templates.go
+++ b/templates/templates.go
@@ -608,6 +608,8 @@ type sourceFS struct {
 
 // Open satisfies the fs.FS interface.
 func (src sourceFS) Open(name string) (fs.File, error) {
+	// Ensure that Windows paths have forward slash
+	name = filepath.ToSlash(name)
 	if name == src.path {
 		return src.fs.Open(".")
 	}


### PR DESCRIPTION
- Ensure windows paths have forward slash.

Fix suggested by [r-lazzaro](https://github.com/pieter-lazzaro).