### PR TITLE
Add JSON methods to sqlite Time type

### DIFF
--- a/_examples/booktest/sqlite3/db.xo.go
+++ b/_examples/booktest/sqlite3/db.xo.go
@@ -209,6 +209,16 @@ func (t *Time) Parse(s string) error {
 	return ErrInvalidTime(s)
 }
 
+// MarshalJSON satisfies the json.Marshaler interface.
+func (t Time) MarshalJSON() ([]byte, error) {
+	return t.time.MarshalJSON()
+}
+
+// UnmarshalJSON satisfies the json.Unmarshaler interface.
+func (t *Time) UnmarshalJSON(data []byte) error {
+	return t.time.UnmarshalJSON(data)
+}
+
 // TimestampFormats are the timestamp formats used by SQLite3 database drivers
 // to store a time.Time in SQLite3.
 //

--- a/templates/go/db.xo.go.tpl
+++ b/templates/go/db.xo.go.tpl
@@ -206,6 +206,16 @@ func (t *Time) Parse(s string) error {
 	return ErrInvalidTime(s)
 }
 
+// MarshalJSON satisfies the json.Marshaler interface.
+func (t Time) MarshalJSON() ([]byte, error) {
+	return t.time.MarshalJSON()
+}
+
+// UnmarshalJSON satisfies the json.Unmarshaler interface.
+func (t *Time) UnmarshalJSON(data []byte) error {
+	return t.time.UnmarshalJSON(data)
+}
+
 // TimestampFormats are the timestamp formats used by SQLite3 database drivers
 // to store a time.Time in SQLite3.
 //


### PR DESCRIPTION
JSON (un)marshaling `Time` doesn't work because the `Time.time` field is unexported. This adds the `MarshalJSON` and `UnmarshalJSON` methods to fix this.