### PR TITLE
fix psql comments

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -157,7 +157,7 @@ SELECT
   c.relname::varchar AS table_name,
   false::boolean AS manual_pk,
   CASE c.relkind
-    WHEN 'r' THEN ''
+    WHEN 'r' THEN COALESCE(obj_description(c.relname::regclass), '')
     WHEN 'v' THEN v.definition
   END AS view_def
 FROM pg_class c

--- a/models/table.xo.go
+++ b/models/table.xo.go
@@ -25,7 +25,7 @@ func PostgresTables(ctx context.Context, db DB, schema, typ string) ([]*Table, e
 		`c.relname, ` + // ::varchar AS table_name
 		`false, ` + // ::boolean AS manual_pk
 		`CASE c.relkind ` +
-		`WHEN 'r' THEN '' ` +
+		`WHEN 'r' THEN COALESCE(obj_description(c.relname::regclass), '') ` +
 		`WHEN 'v' THEN v.definition ` +
 		`END AS view_def ` +
 		`FROM pg_class c ` +

--- a/templates/go/go.go
+++ b/templates/go/go.go
@@ -661,6 +661,7 @@ func convertTable(ctx context.Context, t xo.Table) (Table, error) {
 		Fields:      cols,
 		PrimaryKeys: pkCols,
 		Manual:      t.Manual,
+		Comment:     t.Definition,
 	}, nil
 }
 
@@ -1916,7 +1917,13 @@ func (f *Funcs) field(field Field) (string, error) {
 	if s := buf.String(); s != "" {
 		tag = " `" + s + "`"
 	}
-	return fmt.Sprintf("\t%s %s%s // %s", field.GoName, f.typefn(field.Type), tag, field.SQLName), nil
+
+	comment := field.SQLName
+	if field.Comment != "" {
+		comment = field.Comment
+	}
+
+	return fmt.Sprintf("\t%s %s%s // %s", field.GoName, f.typefn(field.Type), tag, comment), nil
 }
 
 // short generates a safe Go identifier for typ. typ is first checked


### PR DESCRIPTION
For postgresql, comments for tables are not extracted from the database. In addition, the default template does not use information about comments.